### PR TITLE
Update de.po

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -8,8 +8,8 @@ msgstr ""
 "Project-Id-Version: desktitle 0.0.1\n"
 "Report-Msgid-Bugs-To: moksha@bodhilinux.com\n"
 "POT-Creation-Date: 2024-12-13 15:29-0500\n"
-"PO-Revision-Date: 2020-06-13 15:47-0400\n"
-"Last-Translator: Robert Wiley <ylee@bodhilinux.com>\n"
+"PO-Revision-Date: 2024-12-27 15:47-0400\n"
+"Last-Translator:Christian Becker <xpistianbecker@gmail.com>\n"
 "Language-Team: German\n"
 "Language: de\n"
 "MIME-Version: 1.0\n"
@@ -19,36 +19,36 @@ msgstr ""
 
 #: src/e_mod_config.c:40 src/e_mod_config.c:81
 msgid "DeskTitle Settings"
-msgstr ""
+msgstr "DeskTitle Einstellungen"
 
 #: src/e_mod_config.c:83
 msgid "Label color"
-msgstr ""
+msgstr "Labelfarbe"
 
 #: src/e_mod_config.c:85
 msgid "Click for the color selector"
-msgstr ""
+msgstr "Für Farbauswahl klicken"
 
 #: src/e_mod_main.c:197
 msgid "DeskTitle"
-msgstr ""
+msgstr "DeskTitle"
 
 #: src/e_mod_main.c:337
 msgid "Edit Desktop Name"
-msgstr ""
+msgstr "Arbeitsflächennamen bearbeiten"
 
 #: src/e_mod_main.c:338
 msgid "Enter a name for this desktop:"
-msgstr ""
+msgstr "Namen für diese Arbeitsfläche eingeben:"
 
 #: src/e_mod_main.c:339
 msgid "Save"
-msgstr ""
+msgstr "Speichern"
 
 #: src/e_mod_main.c:350
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 #: src/e_mod_main.c:358
 msgid "Virtual Desktops Settings"
-msgstr ""
+msgstr "Einstellungen für virtuelle Arbeitsflächen"


### PR DESCRIPTION
Added translations. Left "DeskTitle" untranslated since I'm not sure whether it is a good idea to translate names. LibreOffice is still LibreOffice in German and not LibreBüro, MS Word is MS Word and not Wort and so on.